### PR TITLE
WEB-334: Fly log shipper initial config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,8 @@
-app = "fly-log-shipper-example"
+app = "logtail-log-shipper"
 
 [metrics]
   port = 9598
   path = "/metrics"
+
+[env]
+  ORG = "udisc"


### PR DESCRIPTION
Initial config for the fly log shipper. Setting an app name and adding UDisc as the org to pull logs from.

Why did I fork this repo? How do I deploy this?
https://www.loom.com/share/7f0b9fac31854816b61a7fc2ee78b362

How is it working?
https://www.loom.com/share/30676596fe974e4985a536de92627446